### PR TITLE
Remove restrictions on the upper limit of node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "jsnext:main": "dist/index.es.js",
   "types": "./dist/index.d.ts",
   "engines": {
-    "node": ">=10 <=12",
+    "node": ">=10",
     "npm": ">=6"
   },
   "scripts": {


### PR DESCRIPTION
We are consuming this project as part of an internal component library; first, thank you for creating and maintaining it! A few of our consumers have begun running into issues building their projects due to the node engine restrictions. 

Opening this up as a starting point to understand why those restrictions are there, feel free to close this if it doesn't make sense for you and we'll publish a fork.