### PR TITLE
add initial tabindex to provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ const SomeComponent = () => (
 
 The default behaviour is selected by setting the direction to `horizontal`. If the direction is set to `vertical` then it is the ArrowUp and ArrowDown keys that are used to move to the previous and next input. If the direction is set to `both` then both the ArrowLeft and ArrowUp keys can be used to move to the previous input, and both the ArrowRight and ArrowDown keys can be used to move to the next input. You can update this `direction` value at any time.
 
+#### Initial index
+
+The `RovingTabIndexProvider` focuses the first element by default. You can pass an initial index to it if you want to focus a specific element.
+
+```ts
+const SomeComponent = () => (
+  <RovingTabIndexProvider initialIndex={5}>
+    {/* whatever */}
+  </RovingTabIndexProvider>
+);
+```
+
 ### Grid usage
 
 This package supports a roving tabindex in a grid. For each usage of the `useRovingTabIndex` hook in the grid, you _must_ pass a row index value as a third argument to the hook:

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -439,16 +439,21 @@ export const RovingTabIndexContext = createContext<Context>({
  * If you do not pass an explicit value then the 'horizontal'
  * behaviour applies. You can change this direction value
  * at any time.
+ * @param {Number} initialIndex The initial index that should be focused when
+ * the component renders for the first time.
  */
 export const Provider = ({
   children,
-  direction = "horizontal"
+  direction = "horizontal",
+  initialIndex
 }: {
   children: ReactNode;
   direction?: KeyDirection;
+  initialIndex?: number;
 }): ReactElement => {
   const [state, dispatch] = useReducer(reducer, {
     ...INITIAL_STATE,
+    selectedId: `rti_${initialIndex}` || null,
     direction
   });
 


### PR DESCRIPTION
Hi Steve! 👋 

Love your package, it helps us make our apps more accessible 🔥 

I'd love to add this small little feature. In some of our widgets, we remember the users choice, so it would be cool when we could sustain focus by providing an initial index.

This small PR implements that feature.

Let me know what you think!