### PR TITLE
add loop around option for uni-dimensional list

### DIFF
--- a/src/stories/toolbar-roving-tabindex.stories.tsx
+++ b/src/stories/toolbar-roving-tabindex.stories.tsx
@@ -44,6 +44,7 @@ const ToolbarButton: FC<{
 
 type ExampleProps = {
   direction: KeyDirection;
+  shouldLoopAround: boolean;
   buttonOneDisabled: boolean;
   onButtonOneClicked: ButtonClickHandler;
   buttonTwoDisabled: boolean;
@@ -59,6 +60,7 @@ type ExampleProps = {
 
 export const ToolbarExample: FC<ExampleProps> = ({
   direction,
+  shouldLoopAround,
   buttonOneDisabled,
   onButtonOneClicked,
   buttonTwoDisabled,
@@ -74,7 +76,10 @@ export const ToolbarExample: FC<ExampleProps> = ({
   <>
     <Button>Something before to focus on</Button>
     <Toolbar role="toolbar">
-      <RovingTabIndexProvider direction={direction}>
+      <RovingTabIndexProvider
+        direction={direction}
+        shouldLoopAround={shouldLoopAround}
+      >
         <span>
           <ToolbarButton
             disabled={!!buttonOneDisabled}
@@ -126,6 +131,10 @@ export default {
     direction: {
       name: "Direction",
       defaultValue: "horizontal"
+    },
+    shouldLoopAround: {
+      name: "Should loop around",
+      defaultValue: false
     },
     onButtonOneClicked: { table: { disable: true } },
     onButtonTwoClicked: { table: { disable: true } },

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export type State = Readonly<{
   allowFocusing: boolean;
   tabStops: readonly TabStop[];
   direction: KeyDirection;
+  shouldLoopAround?: boolean;
   rowStartMap: RowStartMap | null;
 }>;
 
@@ -43,7 +44,8 @@ export enum ActionType {
   KEY_DOWN = "KEY_DOWN",
   CLICKED = "CLICKED",
   TAB_STOP_UPDATED = "TAB_STOP_UPDATED",
-  DIRECTION_UPDATED = "DIRECTION_UPDATED"
+  DIRECTION_UPDATED = "DIRECTION_UPDATED",
+  SHOULD_LOOP_AROUND_UPDATED = "SHOULD_LOOP_AROUND_UPDATED"
 }
 
 export type Action =
@@ -78,6 +80,10 @@ export type Action =
   | {
       type: ActionType.DIRECTION_UPDATED;
       payload: { direction: KeyDirection };
+    }
+  | {
+      type: ActionType.SHOULD_LOOP_AROUND_UPDATED;
+      payload: { shouldLoopAround: boolean };
     };
 
 export type Context = Readonly<{


### PR DESCRIPTION
Following the suggestion made here: #34 

- Added `shouldLoopAround` boolean flag (updates from provider props)
- Implemented loop around navigation in uni-dimensional list (not in grid)

![roving loop around](https://user-images.githubusercontent.com/939567/109291267-0fdbfe00-7829-11eb-8c9c-7b4fa6f6eb4a.gif)
