### PR TITLE
Fixed error on navigation when last grid row doesn't have enough items

### DIFF
--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -248,7 +248,7 @@ export function reducer(state: State, action: Action): State {
                 return state;
               }
               const rowTabStop = state.tabStops[rowStartIndex + columnOffset];
-              if (!rowTabStop.disabled) {
+              if (rowTabStop && !rowTabStop.disabled) {
                 return selectTabStop(state, rowTabStop, rowStartMap);
               }
             }

--- a/src/stories/grid-roving-tabindex.stories.tsx
+++ b/src/stories/grid-roving-tabindex.stories.tsx
@@ -167,14 +167,6 @@ export const GridExample: FC<ExampleProps> = ({
         >
           Button Eleven
         </GridButton>
-        <GridButton
-          disabled={false}
-          useAlternateGridLayout={useAlternateGridLayout}
-          onClick={NOOP_HANDLER}
-          rowIndex={useAlternateGridLayout ? 3 : 2}
-        >
-          Button Twelve
-        </GridButton>
       </RovingTabIndexProvider>
     </Grid>
     <Button>Something after to focus on</Button>


### PR DESCRIPTION
Use case example:

When there total 11 items in a grid with each row having 4 items (and hence 3 rows), if the focus is at last item in the 2nd row, and you press down arrow on keyboard, then there would be a JS error.

That issue is fixed with a falsy-check and the storybook example is modified accordingly to represent that use-case.