### PR TITLE
support a short final row in grid

### DIFF
--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -218,7 +218,7 @@ export function reducer(state: State, action: Action): State {
                 return state;
               }
               const rowTabStop = state.tabStops[rowStartIndex + columnOffset];
-              if (!rowTabStop.disabled) {
+              if (rowTabStop && !rowTabStop.disabled) {
                 return selectTabStop(state, rowTabStop, rowStartMap);
               }
             }
@@ -248,7 +248,7 @@ export function reducer(state: State, action: Action): State {
                 return state;
               }
               const rowTabStop = state.tabStops[rowStartIndex + columnOffset];
-              if (!rowTabStop.disabled) {
+              if (rowTabStop && !rowTabStop.disabled) {
                 return selectTabStop(state, rowTabStop, rowStartMap);
               }
             }

--- a/src/__tests__/Provider.test.ts
+++ b/src/__tests__/Provider.test.ts
@@ -3530,6 +3530,47 @@ describe("reducer", () => {
     });
 
     describe("when tabbing to the next row", () => {
+      describe("when there is no tab stop in the relative position in the next row", () => {
+        const givenState: State = Object.freeze({
+          selectedId: ELEMENT_FOUR_ID,
+          allowFocusing: false,
+          tabStops: [
+            { ...ELEMENT_ONE_TAB_STOP, rowIndex: 0 },
+            { ...ELEMENT_TWO_TAB_STOP, rowIndex: 0 },
+            { ...ELEMENT_THREE_TAB_STOP, rowIndex: 1 },
+            { ...ELEMENT_FOUR_TAB_STOP, rowIndex: 1 },
+            { ...ELEMENT_FIVE_TAB_STOP, rowIndex: 2 }
+          ],
+          direction: "horizontal",
+          focusOnClick: false,
+          loopAround: false,
+          rowStartMap: null
+        });
+
+        const action: Action = {
+          type: ActionType.KEY_DOWN,
+          payload: {
+            id: ELEMENT_FOUR_ID,
+            key: EventKey.ArrowDown,
+            ctrlKey: false
+          }
+        };
+
+        it("should not tab to the next row", () => {
+          const result = reducer(givenState, action);
+          expect(result).toEqual<State>({
+            ...givenState,
+            selectedId: ELEMENT_FOUR_ID,
+            allowFocusing: true,
+            rowStartMap: new Map([
+              [0, 0],
+              [1, 2],
+              [2, 4]
+            ])
+          });
+        });
+      });
+
       describe("when the tab stop in the next row is enabled", () => {
         const givenState: State = Object.freeze({
           selectedId: ELEMENT_TWO_ID,

--- a/src/stories/grid-roving-tabindex.stories.tsx
+++ b/src/stories/grid-roving-tabindex.stories.tsx
@@ -59,6 +59,7 @@ type ExampleProps = {
   buttonFiveDisabled: boolean;
   onButtonFiveClicked: ButtonClickHandler;
   useAlternateGridLayout: boolean;
+  useShortFinalRow: boolean;
 };
 
 export const GridExample: FC<ExampleProps> = ({
@@ -73,7 +74,8 @@ export const GridExample: FC<ExampleProps> = ({
   onButtonFourClicked,
   buttonFiveDisabled,
   onButtonFiveClicked,
-  useAlternateGridLayout
+  useAlternateGridLayout,
+  useShortFinalRow
 }) => (
   <>
     <Button>Something before to focus on</Button>
@@ -167,14 +169,16 @@ export const GridExample: FC<ExampleProps> = ({
         >
           Button Eleven
         </GridButton>
-        <GridButton
-          disabled={false}
-          useAlternateGridLayout={useAlternateGridLayout}
-          onClick={NOOP_HANDLER}
-          rowIndex={useAlternateGridLayout ? 3 : 2}
-        >
-          Button Twelve
-        </GridButton>
+        {!useShortFinalRow && (
+          <GridButton
+            disabled={false}
+            useAlternateGridLayout={useAlternateGridLayout}
+            onClick={NOOP_HANDLER}
+            rowIndex={useAlternateGridLayout ? 3 : 2}
+          >
+            Button Twelve
+          </GridButton>
+        )}
       </RovingTabIndexProvider>
     </Grid>
     <Button>Something after to focus on</Button>
@@ -212,6 +216,9 @@ export default {
     },
     useAlternateGridLayout: {
       name: "Use a 3x4 grid layout"
+    },
+    useShortFinalRow: {
+      name: "Use a short final row"
     }
   },
   parameters: { actions: { argTypesRegex: "^on.*" } }


### PR DESCRIPTION
Change from https://github.com/stevejay/react-roving-tabindex/pull/40 by @webextensions but with additional fix, option in storybook, and unit test.